### PR TITLE
OX-4257 | added output of stdout and stderr of semgrep-core in case of a crash

### DIFF
--- a/cli/src/semgrep/core_runner.py
+++ b/cli/src/semgrep/core_runner.py
@@ -388,7 +388,10 @@ class StreamingSemgrepCore:
         # Raise any exceptions from processing stdout/err
         for r in results:
             if isinstance(r, Exception):
-                raise SemgrepError(f"Error while running rules: {r}")
+                raise SemgrepError("\n".join([
+                    f"Error while running rules: {r}", "core stdout:", self._stdout,
+                    "core stderr:", self._stderr
+                ]))
 
     async def _stream_exec_subprocess(self) -> int:
         """

--- a/cli/src/semgrep/core_runner.py
+++ b/cli/src/semgrep/core_runner.py
@@ -388,10 +388,17 @@ class StreamingSemgrepCore:
         # Raise any exceptions from processing stdout/err
         for r in results:
             if isinstance(r, Exception):
-                raise SemgrepError("\n".join([
-                    f"Error while running rules: {r}", "core stdout:", self._stdout,
-                    "core stderr:", self._stderr
-                ]))
+                raise SemgrepError(
+                    "\n".join(
+                        [
+                            f"Error while running rules: {r}",
+                            "core stdout:",
+                            self._stdout,
+                            "core stderr:",
+                            self._stderr,
+                        ]
+                    )
+                )
 
     async def _stream_exec_subprocess(self) -> int:
         """


### PR DESCRIPTION
[OX-4257](https://oxeye.atlassian.net/browse/OX-4257?atlOrigin=eyJpIjoiYTkyYzU5ZmQ5NWU3NGRmMDllNThhYWNkNWIwY2YzZjMiLCJwIjoiaiJ9)

[OX-4257]: https://oxeye.atlassian.net/browse/OX-4257?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ